### PR TITLE
add init sql of headers table 

### DIFF
--- a/install/orange-v0.7.0.sql
+++ b/install/orange-v0.7.0.sql
@@ -523,6 +523,32 @@ VALUES
 /*!40000 ALTER TABLE `jwt_auth` ENABLE KEYS */;
 UNLOCK TABLES;
 
+# Dump of table headers
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `headers`;
+
+CREATE TABLE `headers` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `key` varchar(255) NOT NULL DEFAULT '',
+  `value` varchar(2000) NOT NULL DEFAULT '',
+  `type` varchar(11) DEFAULT '0',
+  `op_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_key` (`key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+LOCK TABLES `headers` WRITE;
+/*!40000 ALTER TABLE `headers` DISABLE KEYS */;
+
+INSERT INTO `headers` (`id`, `key`, `value`, `type`, `op_time`)
+VALUES
+    (1,'1','{}','meta','2016-11-11 11:11:11');
+
+/*!40000 ALTER TABLE `headers` ENABLE KEYS */;
+UNLOCK TABLES;
+
+
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;


### PR DESCRIPTION
## v0.7.0
I enable headers plugin and add selector, then i get a error log in orange/logs/dashboard_error.log
```
2019/07/11 23:50:06 [error] 23987#0: *13 [lua] mysql_db.lua:36: query(): bad result: Table 'orange.headers' doesn't exist: 1146: 42S02., client: 172.18.1.108, server: , request: "POST /headers/selectors HTTP/1.1", host: "mini1:9999", referrer: "http://mini1:9999/headers"
```
So i do it.