### PR TITLE
change single quotation marks to double quotation marks

### DIFF
--- a/orange/plugins/consul_balancer/README.md
+++ b/orange/plugins/consul_balancer/README.md
@@ -39,7 +39,7 @@
         "host" : "10.0.201.156",
         "port" : 8500,
         "interval" : 10,
-        "token" : 'token'
+        "token" : "token"
     }
     interval计量单位为s
     token为ACL中指定的token,(注，未测试)


### PR DESCRIPTION
* following instructions order 3 in README.md, I add the following configuration into the orange.conf file
```
    "consul": {
        "host" : "10.0.201.156",
        "port" : 8500,
        "interval" : 10,
        "token" : 'token'
    }

```
* then i execute ``` orange start```, i get a error log
```
2019/07/22 18:10:20 [error] 159393#0: [lua] orange.lua:76: init(): Startup error: /usr/local/orange/orange/orange.lua:68: attempt to index upvalue 'config' (a nil value)
```
* because the above configuration is not correct json format. i change single quotation marks to double quotation marks.so it works.