### PR TITLE
nginx默认配置增加 proxy_set_header host

### DIFF
--- a/conf/nginx.conf.example
+++ b/conf/nginx.conf.example
@@ -111,6 +111,7 @@ http {
             }
 
             # proxy
+            proxy_set_header Host $host:$server_port;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
#333 

使用代理/分流插件时，反向代理过去的服务获取不到真实的host
