### PR TITLE
change: update nginx error_log default level to error.

### DIFF
--- a/conf/nginx.conf.example
+++ b/conf/nginx.conf.example
@@ -19,7 +19,7 @@ http {
     '"$upstream_addr" "$upstream_status" "$upstream_response_length" "$upstream_response_time"';
 
     access_log  ./logs/access.log  main;
-    error_log ./logs/error.log info;
+    error_log ./logs/error.log error;
 
     sendfile        on;
     keepalive_timeout  65;


### PR DESCRIPTION
#354 
当前 nginx.conf 中的 error_log 级别为 info，这会造成线上大量的info日志。
nginx 默认 error_log 级别为 error，这应该是推荐的配置。
建议调试时手动修改为 info ，默认级别为 error 让用户减少一些修改的成本。

